### PR TITLE
Remove unused package: platform.

### DIFF
--- a/Tiptabs/main.py
+++ b/Tiptabs/main.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import logging
-import platform
 import requests
 from pathlib import Path
 from Tiptabs.Tiptabs import *


### PR DESCRIPTION
Removes the package platform from main, because this package isn't used throughout the project.
Previous usage of this package has been depreciated through various improvements.