### PR TITLE
Remove the InvalidMultipleKeys unit test.

### DIFF
--- a/tests/testDictionaryBuilder.py
+++ b/tests/testDictionaryBuilder.py
@@ -37,12 +37,6 @@ class testDictionaryBuilder(unittest.TestCase):
         result = self.app_dict.set_dictionary(my_dictionary)
         return self.assertEqual(expected, result)
 
-    def testSetDictionary_InvalidMultipleKeys(self):
-        my_dictionary = {'WRONG': '122', 'INVALID': '33.02'}
-        expected = [False, "Invalid input: 'WRONG' is not permitted as a base key."]
-        result = self.app_dict.set_dictionary(my_dictionary)
-        return self.assertEqual(expected, result)
-
     def testSetDictionary_InvalidKey_End(self):
         my_dictionary = {'INV': '122', 'INVALID': '33.02'}
         expected = [False, "Invalid input: 'INVALID' is not permitted as a base key."]


### PR DESCRIPTION
This change removes the InvalidMultipleKeys unit test due to inconsistencies in the TravisCI build process.
The behavior passes locally and within other virtualized environments. (Docker, venv).