### PR TITLE
Update .dockerignore to ignore pycache directories.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+*/__pycache__/
 .idea
 .DS_Store
 .gitignore


### PR DESCRIPTION
This change ignores __pycache__ directories to decrease Tiptabs' overall Docker image size.