### PR TITLE
Update Makefile test target to escape ending semicolon.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,6 @@ test:
 	make -C tests test
 
 clean:
-	find ./tests/__pycache__ -name '*.pyc' -exec rm --force
+	find ./tests/__pycache__ -type f -name '*.pyc' -exec /bin/rm {} \;
 
 .PHONY: env docker install devel test


### PR DESCRIPTION
This change allows the backend project's Makefile to correctly escape the ending semicolon as required in the `find` command's documentation.