### PR TITLE
Use the --tag flag to name Tiptabs' Docker image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ env:
 
 # Build the docker image
 docker:
-	docker build .
+    docker build --tag tiptabs-app:3.9.0 .
 
 # Install the project
 install:

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ You can build Tiptabs using any of the following methods:
 
     While in the module directory containing the Dockerfile:
     ```sh
-    docker build .
-    ...
-    docker run -it -p 5000:5000 $imageID
+    docker build --tag tiptabs-app:3.9.0 .
+    docker run -p 5000:5000 --detach --name Tiptabs tiptabs-app:3.9.0
     ```
     Docker assembles an image and provides a reference identification number (imageID) for the created image.
     `docker run` runs your newly-created image within an isolated container.
@@ -36,6 +35,7 @@ You can build Tiptabs using any of the following methods:
     The `-p` flag exposes the container's local port of 5000 to the local machine's port of 5000.
     The `$(imageID)` is the provided digit sequence targeting the image made by the Dockerfile.
     The provided requirements.txt file lists dependencies that are installed into the container's virtual environment (venv).
+
 
 3. Build service stack with `docker-compose`.
     As of 2/23/2019 (V3.8.1), a `docker-compose.yml` file is included to build a service stack for the project. To build with `docker-compose`, navigate to the module directory:


### PR DESCRIPTION
This change updates the project's README and Makefile to use reference the `--tag` flag, which names Tiptabs' Docker image when built.

Additionally, instead of running the container interactively, it is suggested to run the container in a detached state, i.e in the background, since most users will just want to use the app.